### PR TITLE
use static for wgs84

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Federico Dolce <psykopear@gmail.com>", "Michael Kirk <michael.code@endoftheworl.de"]
 edition = "2018"
 
+[dependencies]
+lazy_static = "1.4.0"
+
 [dev-dependencies]
 assert_approx_eq = "1.1.0"
 criterion = "0.3.1"

--- a/src/geodesic.rs
+++ b/src/geodesic.rs
@@ -9,7 +9,7 @@ use std::f64::consts::PI;
 pub const WGS84_A: f64 = 6378137.0;
 pub const WGS84_F: f64 = 1.0 / 298.257223563;
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub struct Geodesic {
     pub a: f64,
     pub f: f64,
@@ -38,9 +38,14 @@ pub struct Geodesic {
     xthresh_: f64,
 }
 
+lazy_static! {
+    static ref WGS84_GEOD: Geodesic = Geodesic::new(WGS84_A, WGS84_F);
+}
+
 impl Geodesic {
+
     pub fn wgs84() -> Self {
-        Self::new(WGS84_A, WGS84_F)
+        WGS84_GEOD.clone()
     }
 
     pub fn equatorial_radius(&self) -> f64 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,3 +6,6 @@ pub use geodesiccapability as capability;
 
 mod geodesicline;
 mod geomath;
+
+#[macro_use]
+extern crate lazy_static;


### PR DESCRIPTION
building the Geodesic is a little expensive. Best to create and re-use your own instance of Geodesic, but this makes it cheaper when that's not possible.